### PR TITLE
Events Fixes and Display Runtime

### DIFF
--- a/app/commander/app-commander-events/src/main/java/com/windhoverlabs/yamcs/applications/events/EventViewerController.java
+++ b/app/commander/app-commander-events/src/main/java/com/windhoverlabs/yamcs/applications/events/EventViewerController.java
@@ -47,6 +47,8 @@ public class EventViewerController {
   private String currentServer = "sitl";
   private String currentInstance = "yamcs-cfs";
 
+  YamcsAware yamcsListener = null;
+
   @FXML private GridPane gridPane;
 
   @FXML private ToggleButton scrollLockButton;
@@ -144,7 +146,7 @@ public class EventViewerController {
             sourceCol,
             instanceCol);
 
-    YamcsAware yamcsListener =
+    yamcsListener =
         new YamcsAware() {
           public void changeDefaultInstance() {
             YamcsObjectManager.getDefaultInstance()
@@ -187,6 +189,7 @@ public class EventViewerController {
           }
 
           public void onInstancesReady(YamcsServer s) {
+            System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$onInstancesReady$$$$$$$$$$$$$$$$$$");
             if (s.getDefaultInstance() != null) {
               s.getDefaultInstance()
                   .getEvents()
@@ -209,14 +212,18 @@ public class EventViewerController {
         };
 
     YamcsObjectManager.addYamcsListener(yamcsListener);
-    for (YamcsServer s : YamcsObjectManager.getRoot().getItems()) {
-      s.addListener(yamcsListener);
-    }
+
+    System.out.println("items part of root-->" + YamcsObjectManager.getRoot().getItems());
+    //    for (YamcsServer s : YamcsObjectManager.getRoot().getItems()) {
+    //      s.addListener(yamcsListener);
+    //    }
 
     gridPane.add(tableView, 0, 1);
   }
 
-  public EventViewerController() {}
+  public EventViewerController() {
+    System.out.println("EventViewerController constructor$$$$$$$$$$$$$$");
+  }
 
   private ObservableList<CMDR_Event> generateEvents(int numberOfEvents) {
     ObservableList<CMDR_Event> events = FXCollections.observableArrayList();
@@ -233,5 +240,9 @@ public class EventViewerController {
               "FAKE_INSTANCE"));
     }
     return events;
+  }
+
+  public void unInit() {
+    YamcsObjectManager.removeListener(yamcsListener);
   }
 }

--- a/app/commander/app-commander-events/src/main/java/com/windhoverlabs/yamcs/applications/events/EventViewerController.java
+++ b/app/commander/app-commander-events/src/main/java/com/windhoverlabs/yamcs/applications/events/EventViewerController.java
@@ -3,6 +3,7 @@ package com.windhoverlabs.yamcs.applications.events;
 import com.windhoverlabs.pv.yamcs.YamcsAware;
 import com.windhoverlabs.yamcs.core.CMDR_Event;
 import com.windhoverlabs.yamcs.core.YamcsObjectManager;
+import com.windhoverlabs.yamcs.core.YamcsServer;
 import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -163,9 +164,54 @@ public class EventViewerController {
             tableView.setItems(YamcsObjectManager.getDefaultInstance().getEvents());
             tableView.refresh();
           }
+
+          public void onYamcsConnected() {
+            if (YamcsObjectManager.getDefaultInstance() != null) {
+              YamcsObjectManager.getDefaultInstance()
+                  .getEvents()
+                  .addListener(
+                      new ListChangeListener<Object>() {
+                        @Override
+                        public void onChanged(Change<?> c) {
+                          Platform.runLater(
+                              () -> {
+                                if (!scrollLockButton.isSelected()) {
+                                  tableView.scrollTo(tableView.getItems().size() - 1);
+                                }
+                              });
+                        }
+                      });
+              tableView.setItems(YamcsObjectManager.getDefaultInstance().getEvents());
+              tableView.refresh();
+            }
+          }
+
+          public void onInstancesReady(YamcsServer s) {
+            if (s.getDefaultInstance() != null) {
+              s.getDefaultInstance()
+                  .getEvents()
+                  .addListener(
+                      new ListChangeListener<Object>() {
+                        @Override
+                        public void onChanged(Change<?> c) {
+                          Platform.runLater(
+                              () -> {
+                                if (!scrollLockButton.isSelected()) {
+                                  tableView.scrollTo(tableView.getItems().size() - 1);
+                                }
+                              });
+                        }
+                      });
+              tableView.setItems(YamcsObjectManager.getDefaultInstance().getEvents());
+              tableView.refresh();
+            }
+          }
         };
 
     YamcsObjectManager.addYamcsListener(yamcsListener);
+    for (YamcsServer s : YamcsObjectManager.getRoot().getItems()) {
+      s.addListener(yamcsListener);
+    }
 
     gridPane.add(tableView, 0, 1);
   }

--- a/app/commander/app-commander-events/src/main/java/com/windhoverlabs/yamcs/applications/events/EventViewerInstance.java
+++ b/app/commander/app-commander-events/src/main/java/com/windhoverlabs/yamcs/applications/events/EventViewerInstance.java
@@ -31,10 +31,11 @@ public class EventViewerInstance implements AppInstance {
 
   static EventViewerInstance INSTANCE;
 
-  private final AppDescriptor app;
+  private FXMLLoader loader;
 
-  // TODO: Refactor Tree constructor since we don't need to pass the list of servers anymore.
-  private static EventViewerController eventLog = new EventViewerController();
+  private EventViewerController eventInstanceController = null;
+
+  private final AppDescriptor app;
 
   private DockItem tab = null;
 
@@ -48,6 +49,7 @@ public class EventViewerInstance implements AppInstance {
 
     try {
       content = loader.load();
+      eventInstanceController = loader.getController();
     } catch (IOException e) {
       // TODO Auto-generated catch block
       e.printStackTrace();
@@ -57,12 +59,9 @@ public class EventViewerInstance implements AppInstance {
     tab.addCloseCheck(
         () -> {
           INSTANCE = null;
+          eventInstanceController.unInit();
           return CompletableFuture.completedFuture(true);
         });
-  }
-
-  public static EventViewerController getEventLog() {
-    return eventLog;
   }
 
   @Override
@@ -98,6 +97,10 @@ public class EventViewerInstance implements AppInstance {
 
   public void raise() {
     tab.select();
+  }
+
+  public EventViewerController getController() {
+    return eventInstanceController;
   }
 
   private static ObservableList<String> restoreEvents() {

--- a/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsAware.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsAware.java
@@ -1,5 +1,6 @@
 package com.windhoverlabs.pv.yamcs;
 
+import com.windhoverlabs.yamcs.core.YamcsServer;
 import java.time.Instant;
 import org.yamcs.protobuf.Mdb.SignificanceInfo.SignificanceLevelType;
 import org.yamcs.protobuf.ProcessorInfo;
@@ -14,8 +15,9 @@ public interface YamcsAware {
     changeDefaultInstance();
   }
 
-  default void onInstancesReady() {}
-  ;
+  // TODO:It might worth considering passing the YamcsServer/YamcsInstance object to the
+  // implementors of this function
+  default void onInstancesReady(YamcsServer s) {}
 
   default void onYamcsConnecting() {}
 
@@ -23,6 +25,8 @@ public interface YamcsAware {
   default void onYamcsConnectionFailed(Throwable t) {}
 
   /** Called when we the global connection to yamcs was succesfully established */
+  // TODO:It might worth considering passing the YamcsServer/YamcsInstance object to the
+  // implementors of this function
   default void onYamcsConnected() {}
 
   /** Called when the yamcs is connection went lost */

--- a/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsPVFactory.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsPVFactory.java
@@ -76,7 +76,7 @@ public class YamcsPVFactory implements PVFactory {
       log.warning(String.format("Instance not found for \"%s\" server", serverPath));
       return false;
     }
-    
+
     pvInstance.subscribePV((YamcsPV) pv);
 
     return true;

--- a/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsPVFactory.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsPVFactory.java
@@ -76,7 +76,7 @@ public class YamcsPVFactory implements PVFactory {
       log.warning(String.format("Instance not found for \"%s\" server", serverPath));
       return false;
     }
-
+    
     pvInstance.subscribePV((YamcsPV) pv);
 
     return true;
@@ -216,6 +216,12 @@ public class YamcsPVFactory implements PVFactory {
   public static Collection<YamcsPV> getLocalPVs() {
     synchronized (yamcs_pvs) {
       return yamcs_pvs.values();
+    }
+  }
+
+  static void clearPVs() {
+    synchronized (yamcs_pvs) {
+      yamcs_pvs.clear();
     }
   }
 

--- a/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsSubscriptionService.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/pv/yamcs/YamcsSubscriptionService.java
@@ -56,6 +56,11 @@ public class YamcsSubscriptionService implements YamcsAware, ParameterSubscripti
   private Map<NamedObjectId, Set<YamcsPV>> pvsById = new LinkedHashMap<>();
 
   private ParameterSubscription subscription;
+
+  public ParameterSubscription getSubscription() {
+    return subscription;
+  }
+
   private AtomicBoolean subscriptionDirty = new AtomicBoolean(false);
   private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
@@ -184,7 +189,9 @@ public class YamcsSubscriptionService implements YamcsAware, ParameterSubscripti
   }
 
   public void destroy() {
-    YamcsPlugin.removeListener(this);
+    subscription.cancel(true);
+    pvsById.clear();
+    YamcsPVFactory.clearPVs();
     executor.shutdown();
   }
 

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/CMDR_YamcsInstance.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/CMDR_YamcsInstance.java
@@ -88,6 +88,16 @@ public class CMDR_YamcsInstance extends YamcsObject<YamcsObject<?>> {
         SubscribeEventsRequest.newBuilder().setInstance(getName()).build());
   }
 
+  /**
+   * Initializes all of the subscriptions to the servers such as event and parameter subscriptions.
+   * Always call this AFTER the websocket connection to YAMCS has been established. Ideally inside
+   * the connected() method of a org.yamcs.client.ConnectionListener. Otherwise,
+   * one might cause a race between the time we "connect" via the websocket
+   * and the time we create these subscriptions.
+   *
+   * @param yamcsClient
+   * @param serverName
+   */
   public void activate(YamcsClient yamcsClient, String serverName) {
     initProcessorClient(yamcsClient);
     initYamcsSubscriptionService(yamcsClient, serverName);
@@ -98,6 +108,10 @@ public class CMDR_YamcsInstance extends YamcsObject<YamcsObject<?>> {
   public void deActivate(YamcsClient yamcsClient, String serverName) {
     // TODO:unInit resources...
     instanceState = CMDR_YamcsInstanceState.DEACTIVATED;
+    if (eventSubscription != null) {
+      eventSubscription.cancel(true);
+      paramSubscriptionService.destroy();
+    }
   }
 
   public EventSubscription getEventSubscription() {

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/CMDR_YamcsInstance.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/CMDR_YamcsInstance.java
@@ -91,9 +91,9 @@ public class CMDR_YamcsInstance extends YamcsObject<YamcsObject<?>> {
   /**
    * Initializes all of the subscriptions to the servers such as event and parameter subscriptions.
    * Always call this AFTER the websocket connection to YAMCS has been established. Ideally inside
-   * the connected() method of a org.yamcs.client.ConnectionListener. Otherwise,
-   * one might cause a race between the time we "connect" via the websocket
-   * and the time we create these subscriptions.
+   * the connected() method of a org.yamcs.client.ConnectionListener. Otherwise, one might cause a
+   * race between the time we "connect" via the websocket and the time we create these
+   * subscriptions.
    *
    * @param yamcsClient
    * @param serverName

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsObjectManager.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsObjectManager.java
@@ -119,7 +119,15 @@ public final class YamcsObjectManager {
   }
 
   public static void addYamcsListener(YamcsAware newListener) {
+    System.out.println("addYamcsListener on YamcsServer");
     listeners.add(newListener);
+    if (defaultInstance != null) {
+      newListener.changeDefaultInstance();
+    }
+    System.out.println("addYamcsListener listeners-->" + listeners);
+    //  for (YamcsServer s : YamcsObjectManager.getRoot().getItems()) {
+    //  s.addListener(yamcsListener);
+    // }
   }
 
   /**
@@ -152,5 +160,9 @@ public final class YamcsObjectManager {
       }
     }
     return outServer;
+  }
+
+  public static void removeListener(YamcsAware l) {
+    listeners.remove(l);
   }
 }

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
@@ -89,7 +89,7 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
               if (exc == null) {
                 for (YamcsInstance instance : response) {
                   createAndAddChild(instance.getName());
-
+                  System.out.println("whenComplete1-$$$$$$$$$$");
                   // TODO:Don't really like doing this here...We should either make
                   // YamcsObjectManager
                   // package-private or move all of the code from YamcsObjectManager to this class.
@@ -172,6 +172,8 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
             (response, exc) -> {
               if (exc == null) {
                 for (YamcsInstance instance : response) {
+                  System.out.println("whenComplete2-$$$$$$$$$$");
+                  System.out.println("listeners-->" + listeners.toString());
                   createAndAddChild(instance.getName());
 
                   // TODO:Don't really like doing this here...We should either make

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
@@ -128,8 +128,7 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
             }
 
             @Override
-            public void disconnected() {
-            }
+            public void disconnected() {}
 
             @Override
             public void connectionFailed(Throwable cause) {
@@ -211,8 +210,7 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
             }
 
             @Override
-            public void disconnected() {
-            }
+            public void disconnected() {}
 
             @Override
             public void connectionFailed(Throwable cause) {

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
@@ -2,6 +2,8 @@ package com.windhoverlabs.yamcs.core;
 
 import com.windhoverlabs.pv.yamcs.YamcsAware;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -82,35 +84,6 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
       }
     }
 
-    yamcsClient
-        .listInstances()
-        .whenComplete(
-            (response, exc) -> {
-              if (exc == null) {
-                for (YamcsInstance instance : response) {
-                  createAndAddChild(instance.getName());
-                  System.out.println("whenComplete1-$$$$$$$$$$");
-                  // TODO:Don't really like doing this here...We should either make
-                  // YamcsObjectManager
-                  // package-private or move all of the code from YamcsObjectManager to this class.
-                  //                  if (YamcsObjectManager.getDefaultInstance() != null
-                  //                      && YamcsObjectManager.getDefaultInstance()
-                  //                          .getName()
-                  //                          .equals(instance.getName())) {
-                  //                    YamcsObjectManager.setDefaultInstance(
-                  //                        getName(),
-                  // YamcsObjectManager.getDefaultInstance().getName());
-                  //                  }
-
-                  getItems().get(getItems().size() - 1).activate(yamcsClient, getName());
-
-                  for (YamcsAware l : listeners) {
-                    l.onInstancesReady(this);
-                  }
-                }
-              }
-            });
-
     try {
       yamcsClient.addConnectionListener(
           new ConnectionListener() {
@@ -122,12 +95,40 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
 
             @Override
             public void connected() {
+
+              try {
+                List<YamcsInstance> instances = yamcsClient.listInstances().get();
+                for (YamcsInstance instance : instances) {
+                  createAndAddChild(instance.getName());
+
+                  // TODO:Don't really like doing this here...We should either make
+                  // YamcsObjectManager
+                  // package-private or move all of the code from YamcsObjectManager to this class.
+                  if (YamcsObjectManager.getDefaultInstanceName() != null
+                      && YamcsObjectManager.getDefaultInstanceName().equals(instance.getName())
+                      && YamcsObjectManager.getDefaultServerName().equals(getName())) {
+                    YamcsObjectManager.setDefaultInstance(getName(), instance.getName());
+                  }
+
+                  getItems().get(getItems().size() - 1).activate(yamcsClient, getName());
+
+                  for (YamcsAware l : listeners) {
+                    l.onInstancesReady(getObj());
+                  }
+                }
+              } catch (InterruptedException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+              } catch (ExecutionException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+              }
+
               init();
             }
 
             @Override
             public void disconnected() {
-              disconnect();
             }
 
             @Override
@@ -154,6 +155,7 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
     if (yamcsClient != null) {
       yamcsClient.close();
     }
+
     yamcsClient = YamcsClient.newBuilder(connection.getUrl(), connection.getPort()).build();
 
     if (connection.getPassword() != null && connection.getUser() != null) {
@@ -166,34 +168,6 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
       }
     }
 
-    yamcsClient
-        .listInstances()
-        .whenComplete(
-            (response, exc) -> {
-              if (exc == null) {
-                for (YamcsInstance instance : response) {
-                  System.out.println("whenComplete2-$$$$$$$$$$");
-                  System.out.println("listeners-->" + listeners.toString());
-                  createAndAddChild(instance.getName());
-
-                  // TODO:Don't really like doing this here...We should either make
-                  // YamcsObjectManager
-                  // package-private or move all of the code from YamcsObjectManager to this class.
-                  if (YamcsObjectManager.getDefaultInstanceName() != null
-                      && YamcsObjectManager.getDefaultInstanceName().equals(instance.getName())
-                      && YamcsObjectManager.getDefaultServerName().equals(this.getName())) {
-                    YamcsObjectManager.setDefaultInstance(getName(), instance.getName());
-                  }
-
-                  getItems().get(getItems().size() - 1).activate(yamcsClient, getName());
-
-                  for (YamcsAware l : listeners) {
-                    l.onInstancesReady(this);
-                  }
-                }
-              }
-            });
-
     try {
       yamcsClient.addConnectionListener(
           new ConnectionListener() {
@@ -205,12 +179,39 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
 
             @Override
             public void connected() {
+
+              try {
+                List<YamcsInstance> instances = yamcsClient.listInstances().get();
+                for (YamcsInstance instance : instances) {
+                  createAndAddChild(instance.getName());
+
+                  // TODO:Don't really like doing this here...We should either make
+                  // YamcsObjectManager
+                  // package-private or move all of the code from YamcsObjectManager to this class.
+                  if (YamcsObjectManager.getDefaultInstanceName() != null
+                      && YamcsObjectManager.getDefaultInstanceName().equals(instance.getName())
+                      && YamcsObjectManager.getDefaultServerName().equals(getName())) {
+                    YamcsObjectManager.setDefaultInstance(getName(), instance.getName());
+                  }
+
+                  getItems().get(getItems().size() - 1).activate(yamcsClient, getName());
+
+                  for (YamcsAware l : listeners) {
+                    l.onInstancesReady(getObj());
+                  }
+                }
+              } catch (InterruptedException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+              } catch (ExecutionException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+              }
               init();
             }
 
             @Override
             public void disconnected() {
-              disconnect();
             }
 
             @Override
@@ -234,8 +235,6 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
       instance.deActivate(yamcsClient, this.getName());
     }
     this.getItems().clear();
-    serverState = ConnectionState.DISCONNECTED;
-    serverStateStrProperty.set(this.toString());
   }
 
   private void init() {
@@ -248,11 +247,13 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
   }
 
   public void disconnect() {
+    unInit();
+    serverState = ConnectionState.DISCONNECTED;
+    serverStateStrProperty.set(this.toString());
     // TODO: unInit resources such as event subscriptions, parameter subscriptions, etc
     if (yamcsClient != null) {
       yamcsClient.close();
     }
-    unInit();
   }
 
   public YamcsServerConnection getConnection() {
@@ -302,11 +303,6 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
               .build();
 
       if (newConnection.getPassword() != null && newConnection.getUser() != null) {
-        System.out.println(
-            "*************************************************:"
-                + newConnection.getPassword()
-                + "---"
-                + newConnection.getUser());
         yamcsClient.login(newConnection.getUser(), newConnection.getPassword().toCharArray());
       }
 
@@ -324,5 +320,9 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
 
   public final String toString() {
     return getName() + " | " + getServerState();
+  }
+
+  private YamcsServer getObj() {
+    return this;
   }
 }

--- a/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
+++ b/core/commander-core/src/main/java/com/windhoverlabs/yamcs/core/YamcsServer.java
@@ -57,6 +57,9 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
   }
 
   public void addListener(YamcsAware newListener) {
+    if (serverState == ConnectionState.CONNECTED) {
+      newListener.onInstancesReady(this);
+    }
     listeners.add(newListener);
   }
 
@@ -102,7 +105,7 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
                   getItems().get(getItems().size() - 1).activate(yamcsClient, getName());
 
                   for (YamcsAware l : listeners) {
-                    l.onInstancesReady();
+                    l.onInstancesReady(this);
                   }
                 }
               }
@@ -183,7 +186,7 @@ public class YamcsServer extends YamcsObject<CMDR_YamcsInstance> {
                   getItems().get(getItems().size() - 1).activate(yamcsClient, getName());
 
                   for (YamcsAware l : listeners) {
-                    l.onInstancesReady();
+                    l.onInstancesReady(this);
                   }
                 }
               }


### PR DESCRIPTION
- Fixed various bugs related to Events.
- Fixed various bugs related to PVs. Essentially anytime the server was disconnected(and the user reconnected) the display runtime would use the cached old(and invalid) PVs. That has been fixed in this PR.
- Closes #48
- Closes #54 